### PR TITLE
Updated CircleCI config to include orb usage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,22 @@
-version: 2
+version: 2.1
+
+orbs:
+  node: circleci/node@lts
+
 jobs:
   build:
-    docker:
-      - image: cimg/node:lts
+    executor:
+      name: node/default
     steps:
       - checkout
-      - run: yarn install
-      - run: yarn test
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          name: test
+          command: yarn run test
+
+workflows:
+  build:
+    jobs:
+      - test
+        


### PR DESCRIPTION
Configured the usage of the now recommended [CircleCI Node Orb](https://circleci.com/developer/orbs/orb/circleci/node).

_Please label the PR as `Orbtoberfest` if accepted/merged. Thanks!_